### PR TITLE
fix issue of using absolute path of executable in powershell

### DIFF
--- a/src/VSCodeUI.ts
+++ b/src/VSCodeUI.ts
@@ -15,7 +15,21 @@ export namespace VSCodeUI {
         if (cwd) {
             terminals[name].sendText(getCDCommand(cwd), true);
         }
-        terminals[name].sendText(command, addNewLine);
+        terminals[name].sendText(getCommand(command), addNewLine);
+    }
+
+    export function getCommand(cmd: string): string {
+        if (os.platform() === "win32") {
+            const windowsShell: string = workspace.getConfiguration("terminal").get<string>("integrated.shell.windows")
+                .toLowerCase();
+            if (windowsShell && windowsShell.indexOf("powershell.exe") > -1) {
+                return `& ${cmd}`; // PowerShell
+            } else {
+                return cmd; // others, try using common one.
+            }
+        } else {
+            return cmd;
+        }
     }
 
     export function getCDCommand(cwd: string): string {


### PR DESCRIPTION
add `&` before command in powershell

Previous:
```
PS C:\Users\yanzh\Documents\WorkingDirectories\VSCodeJavaDebugger\java-debug>"C:\Users\yanzh\AppData\Local\apache-maven 3.5.0\bin\mvn.cmd" clean -f "com.microsoft.java.debug.core\pom.xml"At line:1 char:63
+ ... ers\yanzh\AppData\Local\apache-maven 3.5.0\bin\mvn.cmd" clean -f "com ...
+                                                             ~~~~~
Unexpected token 'clean' in expression or statement.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : UnexpectedToken
```

Now:
```
PS C:\Users\yanzh\Documents\WorkingDirectories\VSCodeJavaDebugger\java-debug>& "C:\Users\yanzh\AppData\Local\apache-maven 3.5.0\bin\mvn.cmd" clean -f "com.microsoft.java.debug.core\pom.xml"
[INFO] Scanning for projects...
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Building Java Debug Server for Visual Studio Code :: Debugger Core 0.3.1
[INFO] ------------------------------------------------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ com.microsoft.java.debug.core ---
[INFO] Deleting C:\Users\yanzh\Documents\WorkingDirectories\VSCodeJavaDebugger\java-debug\com.microsoft.java.debug.core\target
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.058 s
[INFO] Finished at: 2017-12-19T10:24:50+08:00
[INFO] Final Memory: 8M/245M
[INFO] ------------------------------------------------------------------------
```